### PR TITLE
Adding support for tftp type of installation.

### DIFF
--- a/components/os-installer.sh
+++ b/components/os-installer.sh
@@ -84,7 +84,7 @@ do sleep 1
 done
 
 echo "Installing image from ${image_location}..."
-wget -O- "${image_location}" | bzip2 -dc | ./partclone.restore -q -s - -o "${target_dev}"2 || {
+./curl -s "${image_location}" | bzip2 -dc | ./partclone.restore -s - -o "${target_dev}"2 || {
 echo "Image installation failed."
 exit 1
 }


### PR DESCRIPTION
Fixing #3.

Original script used wget that doesn't support tftp.
Reworking script to use tftp from ONIE has limitations as tftp from
busybox doesn't have ability to store to standard output and show status
of downloaded image.
That's why we decided to integrate 'curl' binary and use it for all
downloads.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>