### PR TITLE
Issue 21749: Remove extra output from onie installation.

### DIFF
--- a/components/os-installer.sh
+++ b/components/os-installer.sh
@@ -124,7 +124,7 @@ ${reserved_dev_num}
 ${reserved_dev_start}
 ${reserved_dev_end}
 
-w" | fdisk $target_dev
+w" | fdisk $target_dev &>/dev/null
 
 echo "Installing image from ${image_location}..."
 ./curl -s "${image_location}" | bzip2 -dc | ./partclone.restore -s - -o "${target_dev}"2 || {


### PR DESCRIPTION
Modified output:
```
ONIE:/ # onie-nos-install http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2.sh
discover: installer mode detected.
Stopping: discover... done.
Info: Attempting http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2.sh ...
Connecting to 192.168.157.126 (192.168.157.126:80)
installer            100% |*******************************|  1069k  0:00:00 ETA
ONIE: Executing installer: http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2.sh
Verifying image checksum ... OK.
Unpacking the installer ... done.
Check image file presence at http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2-image.bin...
Image http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2-image.bin is OK...
Installing image from http://192.168.157.126/images/bb-pkgs/iss-partclone.img.ext2-image.bin...
Partclone v0.2.70 http://partclone.org
Starting to restore image (-) to device (/dev/sda2)
Calculating bitmap... Please wait...
done!
File system:  EXTFS
Device size:   10.3 GB = 2503640 Blocks
Space in use:   2.9 GB = 695845 Blocks
Free Space:     7.4 GB = 1807795 Blocks
Block size:   4096 Byte
Elapsed: 00:09:00, Remaining: 00:00:00, Completed: 100.00%, Rate: 316.69MB/min,
current block:    2496451, total block:    2503640, Complete: 100.00%
Total Time: 00:09:00, Ave. Rate:  316.7MB/min, 100.00% completed!
Syncing... OK!
Partclone successfully restored the image (-) to the device (/dev/sda2)
Cloned successfully.
Mounting target root filesystem...
Done.
Saving /boot directory on the target root filesystem...
Done.
Removing /boot directory from the target root filesystem...
. . .
========================================================================

sh-4.4# fdisk -l /dev/sda
Disk /dev/sda: 29.8 GiB, 32017047552 bytes, 62533296 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x000bc446

Device     Boot    Start      End  Sectors  Size Id Type
/dev/sda1  *        2048   264191   262144  128M 83 Linux
/dev/sda2         264192 31133969 30869778 14.7G 83 Linux
/dev/sda3       31133970 62524979 31391010   15G 83 Linux
sh-4.4# 
```