### PR TITLE
[NR-13503][EFI]: Use efi way to load linux and initrd with GRUB

### DIFF
--- a/components/50_onie_grub_imt
+++ b/components/50_onie_grub_imt
@@ -103,6 +103,14 @@ cat << EOF
 
 submenu "\$onie_submenu" {
 EOF
+
+GRUB_LINUX_CMD="linux"
+GRUB_INITRD_CMD="initrd"
+if [ -d "/sys/firmware/efi/efivars" ]; then
+    GRUB_LINUX_CMD="linuxefi"
+    GRUB_INITRD_CMD="initrdefi"
+fi
+
 for mode in install rescue uninstall update embed ; do
     case "\$mode" in
         install)
@@ -128,8 +136,8 @@ menuentry "\$onie_menu_$mode" --unrestricted {
         onie_entry_start
         echo    "\$boot_message"
         onie_args="${ONIE_CMDLINE} ${ONIE_EXTRA_CMDLINE_LINUX}"
-        linux   /onie/vmlinuz-\${onie_kernel_version}-onie \${onie_args} boot_reason=$mode
-        initrd  /onie/initrd.img-\${onie_kernel_version}-onie
+        ${GRUB_LINUX_CMD}   /onie/vmlinuz-\${onie_kernel_version}-onie \${onie_args} boot_reason=$mode
+        ${GRUB_INITRD_CMD}  /onie/initrd.img-\${onie_kernel_version}-onie
         onie_entry_end
 }
 EOF


### PR DESCRIPTION
Use EFI way to boot linux. GRUB suggests two commands ```linuxefi``` and ```initrdefi```.
So ```error: no suitable video mode found.``` is gone.

Related changes:
https://github.com/IMT-Internal/onie/pull/21
https://github.com/IMT-Internal/iss/pull/7200